### PR TITLE
docker: Build without rw output since this is now in the core k6 project

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@ FROM golang:1.19-alpine as builder
 WORKDIR "$GOPATH"/src/go.k6.io/k6
 
 RUN go install go.k6.io/xk6/cmd/xk6@latest && \
-    xk6 build --with github.com/grafana/xk6-client-prometheus-remote@main \
-    --with github.com/grafana/xk6-output-prometheus-remote@latest && \
+    xk6 build --with github.com/grafana/xk6-client-prometheus-remote@main && \
     cp k6 "$GOPATH"/bin/k6
 
 FROM alpine:3.13


### PR DESCRIPTION
See https://github.com/grafana/xk6-output-prometheus-remote/pull/151